### PR TITLE
Expose all Actuator endpoints including HTTP traces

### DIFF
--- a/src/main/kotlin/dev/pankowski/garcon/configuration/ActuatorConfiguration.kt
+++ b/src/main/kotlin/dev/pankowski/garcon/configuration/ActuatorConfiguration.kt
@@ -1,0 +1,12 @@
+package dev.pankowski.garcon.configuration
+
+import org.springframework.boot.actuate.trace.http.InMemoryHttpTraceRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ActuatorConfiguration {
+
+  @Bean
+  fun httpTraceRepository() = InMemoryHttpTraceRepository()
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,11 +34,10 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: '*'
       base-path: /internal
   endpoint:
     health:
-      enabled: true
       show-details: always
 
 lunch:

--- a/src/test/kotlin/dev/pankowski/garcon/integration/ActuatorIT.kt
+++ b/src/test/kotlin/dev/pankowski/garcon/integration/ActuatorIT.kt
@@ -78,5 +78,25 @@ class ActuatorIT : CommonIT() {
         .body("components.diskSpace.details.total", notEmpty())
         .body("components.diskSpace.details.free", notEmpty())
     }
+
+    "HTTP trace endpoint is enabled" {
+      // given
+      val specification = request()
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+
+      // when
+      val response = specification
+        .get("/internal/httptrace")
+
+      // then
+      response
+        .then()
+        .log().all()
+        .assertThat()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .and()
+        .body("traces", notNullValue())
+    }
   }
 }


### PR DESCRIPTION
Expose all Actuator endpoints including HTTP traces kept in memory.