### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@v1
-      if: always() && (steps.test.conclusion != 'skipped')
+      if: always() && (steps.test.conclusion != 'skipped') && (github.event_name == 'pull_request')
       with:
         check_name: Test Results
         files: build/test-results/**/*.xml


### PR DESCRIPTION
Publish test result comments only in case of PRs (and not on push to main branch)