### PR TITLE
Preparation before decoupling of post diff calculation logic

### DIFF
--- a/src/main/kotlin/dev/pankowski/garcon/domain/FacebookPostClient.kt
+++ b/src/main/kotlin/dev/pankowski/garcon/domain/FacebookPostClient.kt
@@ -4,5 +4,11 @@ import java.time.Instant
 
 interface FacebookPostClient {
 
+  /**
+   * Fetches posts of lunch page described by given configuration.
+   *
+   * Publication date-time of last seen post acts as a hint. Implementation <em>can</em> return posts published before
+   * that date-time. However, it should always attempt to return all posts published after that date-time.
+   */
   fun fetch(pageConfig: LunchPageConfig, lastSeenPublishedAt: Instant?): Pair<PageName?, Posts>
 }

--- a/src/main/kotlin/dev/pankowski/garcon/domain/FacebookPostClient.kt
+++ b/src/main/kotlin/dev/pankowski/garcon/domain/FacebookPostClient.kt
@@ -1,14 +1,9 @@
 package dev.pankowski.garcon.domain
 
-import java.time.Instant
-
 interface FacebookPostClient {
 
   /**
    * Fetches posts of lunch page described by given configuration.
-   *
-   * Publication date-time of last seen post acts as a hint. Implementation <em>can</em> return posts published before
-   * that date-time. However, it should always attempt to return all posts published after that date-time.
    */
-  fun fetch(pageConfig: LunchPageConfig, lastSeenPublishedAt: Instant?): Pair<PageName?, Posts>
+  fun fetch(pageConfig: LunchPageConfig): Pair<PageName?, Posts>
 }

--- a/src/main/kotlin/dev/pankowski/garcon/domain/LunchService.kt
+++ b/src/main/kotlin/dev/pankowski/garcon/domain/LunchService.kt
@@ -43,9 +43,8 @@ class LunchService(
 
     val lastSeen = repository.findLastSeen(pageConfig.id)
     val (pageName, posts) = postClient.fetch(pageConfig, lastSeen?.post?.publishedAt)
-    val newPosts = posts
-      .filter { it.publishedAt > (lastSeen?.post?.publishedAt ?: Instant.MIN) }
 
+    val newPosts = posts.filter { it.publishedAt > (lastSeen?.post?.publishedAt ?: Instant.MIN) }
     if (newPosts.isEmpty()) {
       log.info("No new posts")
       return emptyList()

--- a/src/main/kotlin/dev/pankowski/garcon/domain/LunchService.kt
+++ b/src/main/kotlin/dev/pankowski/garcon/domain/LunchService.kt
@@ -42,7 +42,7 @@ class LunchService(
     log.info("Synchronizing posts of {}", pageConfig)
 
     val lastSeen = repository.findLastSeen(pageConfig.id)
-    val (pageName, posts) = postClient.fetch(pageConfig, lastSeen?.post?.publishedAt)
+    val (pageName, posts) = postClient.fetch(pageConfig)
 
     val newPosts = posts.filter { it.publishedAt > (lastSeen?.post?.publishedAt ?: Instant.MIN) }
     if (newPosts.isEmpty()) {

--- a/src/main/kotlin/dev/pankowski/garcon/infrastructure/JsoupFacebookPostClient.kt
+++ b/src/main/kotlin/dev/pankowski/garcon/infrastructure/JsoupFacebookPostClient.kt
@@ -20,7 +20,7 @@ class JsoupFacebookPostClient(private val clientConfig: ClientConfig) : Facebook
 
   private val log: Logger = LoggerFactory.getLogger(javaClass)
 
-  override fun fetch(pageConfig: LunchPageConfig, lastSeenPublishedAt: Instant?): Pair<PageName?, Posts> {
+  override fun fetch(pageConfig: LunchPageConfig): Pair<PageName?, Posts> {
     val document = fetchDocument(pageConfig.url)
     val pageName = extractPageName(document, pageConfig)
     val posts = extractPosts(document).sortedBy { it.publishedAt }

--- a/src/main/kotlin/dev/pankowski/garcon/infrastructure/JsoupFacebookPostClient.kt
+++ b/src/main/kotlin/dev/pankowski/garcon/infrastructure/JsoupFacebookPostClient.kt
@@ -23,9 +23,7 @@ class JsoupFacebookPostClient(private val clientConfig: ClientConfig) : Facebook
   override fun fetch(pageConfig: LunchPageConfig, lastSeenPublishedAt: Instant?): Pair<PageName?, Posts> {
     val document = fetchDocument(pageConfig.url)
     val pageName = extractPageName(document, pageConfig)
-    val posts = extractPosts(document)
-      .sortedBy(Post::publishedAt)
-      .filter { it.publishedAt > (lastSeenPublishedAt ?: Instant.MIN) }
+    val posts = extractPosts(document).sortedBy { it.publishedAt }
     return pageName to posts
   }
 

--- a/src/test/kotlin/dev/pankowski/garcon/domain/LunchServiceTest.kt
+++ b/src/test/kotlin/dev/pankowski/garcon/domain/LunchServiceTest.kt
@@ -27,7 +27,7 @@ class LunchServiceTest : FreeSpec({
     )
 
     every { repository.findLastSeen(any()) } returns null
-    every { postClient.fetch(any(), any()) } returns Pair(null, emptyList())
+    every { postClient.fetch(any()) } returns Pair(null, emptyList())
 
     // when
     service.synchronizeAll()
@@ -63,7 +63,7 @@ class LunchServiceTest : FreeSpec({
         Repost.Skip
       )
 
-    every { postClient.fetch(any(), any()) } returns Pair(somePageName(), emptyList())
+    every { postClient.fetch(any()) } returns Pair(somePageName(), emptyList())
 
     // when
     service.synchronize(pageConfig)
@@ -71,7 +71,7 @@ class LunchServiceTest : FreeSpec({
     // then
     verify {
       repository.findLastSeen(pageConfig.id)
-      postClient.fetch(pageConfig, lastSeenPublishedAt)
+      postClient.fetch(pageConfig)
       postClassifier wasNot Called
       reposter wasNot Called
     }
@@ -90,7 +90,7 @@ class LunchServiceTest : FreeSpec({
     val repository = spyk(InMemorySynchronizedPostRepository())
     val service = LunchService(someLunchConfig(), mockk(), repository, postClient, postClassifier, reposter)
 
-    every { postClient.fetch(pageConfig, any()) } returns Pair(pageName, listOf(post))
+    every { postClient.fetch(pageConfig) } returns Pair(pageName, listOf(post))
     every { postClassifier.classify(post) } returns classification
     every { reposter.repost(post, pageName) } returns Unit
 
@@ -121,7 +121,7 @@ class LunchServiceTest : FreeSpec({
     val repository = spyk(InMemorySynchronizedPostRepository())
     val service = LunchService(someLunchConfig(), mockk(), repository, postClient, postClassifier, reposter)
 
-    every { postClient.fetch(pageConfig, any()) } returns Pair(somePageName(), listOf(post))
+    every { postClient.fetch(pageConfig) } returns Pair(somePageName(), listOf(post))
     every { postClassifier.classify(post) } returns classification
 
     // when

--- a/src/test/kotlin/dev/pankowski/garcon/infrastructure/JsoupFacebookPostClientTest.kt
+++ b/src/test/kotlin/dev/pankowski/garcon/infrastructure/JsoupFacebookPostClientTest.kt
@@ -273,34 +273,6 @@ class JsoupFacebookPostClientTest : FreeSpec({
     )
   }
 
-  "returns posts newer than specified published date" {
-    // given
-    val client = JsoupFacebookPostClient(someClientConfig())
-    val pageConfig = somePageConfig(url = URL(server.url("/posts")))
-
-    // and
-    server.givenThat(
-      get("/posts")
-        .willReturn(okHtml(htmlFrom("/lunch/facebook/post-sorting-test.html")))
-    )
-
-    // when
-    val nameAndPosts = client.fetch(pageConfig, Instant.ofEpochSecond(1))
-
-    // then
-    nameAndPosts shouldBe Pair(
-      null,
-      listOf(
-        Post(
-          ExternalId("2"),
-          URL("https://www.facebook.com/2"),
-          Instant.ofEpochSecond(2),
-          "Some content 2"
-        )
-      )
-    )
-  }
-
   "extracts posts from a real page" {
     // given
     val client = JsoupFacebookPostClient(someClientConfig())

--- a/src/test/kotlin/dev/pankowski/garcon/infrastructure/JsoupFacebookPostClientTest.kt
+++ b/src/test/kotlin/dev/pankowski/garcon/infrastructure/JsoupFacebookPostClientTest.kt
@@ -37,7 +37,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
     )
 
     // when
-    client.fetch(pageConfig, null)
+    client.fetch(pageConfig)
 
     // then
     server.verify(
@@ -64,7 +64,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
 
     // expect
     shouldThrow<SocketTimeoutException> {
-      client.fetch(pageConfig, null)
+      client.fetch(pageConfig)
     }
   }
 
@@ -106,7 +106,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
     )
 
     // when
-    val nameAndPosts = client.fetch(pageConfig, null)
+    val nameAndPosts = client.fetch(pageConfig)
 
     // then
     nameAndPosts shouldBe Pair(null, emptyList())
@@ -153,7 +153,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
 
     // expect
     shouldThrow<HttpStatusException> {
-      client.fetch(pageConfig, null)
+      client.fetch(pageConfig)
     }
   }
 
@@ -169,7 +169,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
     )
 
     // when
-    val nameAndPosts = client.fetch(pageConfig, null)
+    val nameAndPosts = client.fetch(pageConfig)
 
     // then
     nameAndPosts shouldBe Pair(PageName("Some Lunch Page Name"), emptyList())
@@ -187,7 +187,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
     )
 
     // when
-    val nameAndPosts = client.fetch(pageConfig, null)
+    val nameAndPosts = client.fetch(pageConfig)
 
     // then
     nameAndPosts shouldBe Pair(null, emptyList())
@@ -205,7 +205,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
     )
 
     // when
-    val nameAndPosts = client.fetch(pageConfig, null)
+    val nameAndPosts = client.fetch(pageConfig)
 
     // then
     nameAndPosts shouldBe Pair(
@@ -233,7 +233,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
     )
 
     // when
-    val nameAndPosts = client.fetch(pageConfig, null)
+    val nameAndPosts = client.fetch(pageConfig)
 
     // then
     nameAndPosts shouldBe Pair(null, emptyList())
@@ -251,7 +251,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
     )
 
     // when
-    val nameAndPosts = client.fetch(pageConfig, null)
+    val nameAndPosts = client.fetch(pageConfig)
 
     // then
     nameAndPosts shouldBe Pair(
@@ -285,7 +285,7 @@ class JsoupFacebookPostClientTest : FreeSpec({
     )
 
     // when
-    val nameAndPosts = client.fetch(pageConfig, null)
+    val nameAndPosts = client.fetch(pageConfig)
 
     // then
     nameAndPosts shouldBe Pair(


### PR DESCRIPTION
This PR introduces minimal prep work before introducing a bit more full-blown post difference calculation logic. The aim is to decouple this logic from both the service and the post client.

This logic might be a base for further features like:
* deleting reposts on Slack whenever corresponding post is deleted on Facebook,
* updating lunch posts on Slack based on changes to corresponding post on Facebook,
* deleting repost on Slack / re-post post from Facebook in case the change changes whether a post is considered a lunch post, etc.