### PR TITLE
Remove --stop parameter from Sonar Scanner invocation

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: ./gradlew sonarqube --stop --info
+      run: ./gradlew sonarqube --info
 
     - name: Build docker image
       uses: docker/build-push-action@v3


### PR DESCRIPTION
It seems to stop Gradle daemon instances without running the Sonar task