### PR TITLE
Preparation for new post extraction strategy

### DIFF
--- a/src/main/kotlin/dev/pankowski/garcon/infrastructure/facebook/FacebookPostExtractionStrategyV1.kt
+++ b/src/main/kotlin/dev/pankowski/garcon/infrastructure/facebook/FacebookPostExtractionStrategyV1.kt
@@ -12,6 +12,11 @@ import java.net.URI
 import java.net.URL
 import java.time.Instant
 
+/**
+ * Post extraction strategy viable until H1 2022, extracting posts from Facebook page DOM which
+ * (back then) was server-side rendered. As a result, parts of post information was pretty easily
+ * identifiable in the DOM.
+ */
 @Component
 class FacebookPostExtractionStrategyV1 : FacebookPostExtractionStrategy {
 

--- a/src/main/kotlin/dev/pankowski/garcon/infrastructure/facebook/JsoupFacebookPostClient.kt
+++ b/src/main/kotlin/dev/pankowski/garcon/infrastructure/facebook/JsoupFacebookPostClient.kt
@@ -52,6 +52,11 @@ class JsoupFacebookPostClient(
         .header("Accept-Language", "pl,en;q=0.5")
         .header("Cache-Control", "no-cache")
         .header("Pragma", "no-cache")
+        .header("DNT", "1")
+        .header("Sec-Fetch-Dest", "document")
+        .header("Sec-Fetch-Mode", "navigate")
+        .header("Sec-Fetch-Site", "none")
+        .header("Sec-Fetch-User", "?1")
         .timeout(clientConfig.timeout.toMillis().toInt())
         .get()
 

--- a/src/test/kotlin/dev/pankowski/garcon/infrastructure/facebook/JsoupFacebookPostClientTest.kt
+++ b/src/test/kotlin/dev/pankowski/garcon/infrastructure/facebook/JsoupFacebookPostClientTest.kt
@@ -57,6 +57,11 @@ class JsoupFacebookPostClientTest : FreeSpec({
         .withHeader("Accept-Language", equalTo("pl,en;q=0.5"))
         .withHeader("Cache-Control", equalTo("no-cache"))
         .withHeader("Pragma", equalTo("no-cache"))
+        .withHeader("DNT", equalTo("1"))
+        .withHeader("Sec-Fetch-Dest", equalTo("document"))
+        .withHeader("Sec-Fetch-Mode", equalTo("navigate"))
+        .withHeader("Sec-Fetch-Site", equalTo("none"))
+        .withHeader("Sec-Fetch-User", equalTo("?1"))
     )
   }
 


### PR DESCRIPTION
Add new required headers for DOM fetching. The seem to be required to get the actual Facebook page and not the login screen page.