### PR TITLE
Limit build concurrency

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -13,6 +13,10 @@ env:
   # Print JVM flags in debug mode. Uses simulated ternary operator (see https://github.com/actions/runner/issues/409).
   JAVA_TOOL_OPTIONS: ${{ secrets.ACTIONS_STEP_DEBUG == 'true' && '-XX:+PrintFlagsFinal' || '' }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Limit build concurrency to 1 build per workflow per branch.

This should reduce number of builds in these cases:

* PRs merged in close succession (resulting in many `main` builds),
* commits pushed to feature branch in close succession (resulting in many feature branch builds).