### PR TITLE
Upgrade WireMock

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencyManagement {
     dependency("io.kotest.extensions:kotest-extensions-spring:1.1.3")
     dependency("io.kotest.extensions:kotest-extensions-wiremock:2.0.1")
     dependency("io.mockk:mockk:1.13.8")
-    dependency("com.github.tomakehurst:wiremock-standalone:3.0.1")
+    dependency("org.wiremock:wiremock-standalone:3.3.1")
     dependency("com.tngtech.archunit:archunit-junit5:1.2.1")
   }
 }
@@ -84,13 +84,13 @@ dependencies {
   testImplementation("io.kotest:kotest-assertions-core")
   testImplementation("io.kotest.extensions:kotest-extensions-spring")
   testImplementation("io.kotest.extensions:kotest-extensions-wiremock") {
-    // Remove once kotest-extensions-wiremock references renamed "wiremock-standalone"
+    // Remove once kotest-extensions-wiremock migrates to the renamed org.wiremock:wiremock-standalone
     exclude("com.github.tomakehurst", "wiremock-jre8-standalone")
   }
 
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("io.rest-assured:rest-assured")
-  testImplementation("com.github.tomakehurst:wiremock-standalone")
+  testImplementation("org.wiremock:wiremock-standalone")
   testImplementation("com.tngtech.archunit:archunit-junit5")
 
   // Other


### PR DESCRIPTION
Upgrade WireMock, which also changed its group ID to `org.wiremock`